### PR TITLE
Improve unity support

### DIFF
--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
@@ -29,28 +29,34 @@ namespace Serilog.Sinks.Unity3D
             {
                 _formatter.Format(logEvent, buffer);
 
-                var level = logEvent.Level switch
+                LogType logType = LogType.Log;
+                switch (logEvent.Level)
                 {
-                    LogEventLevel.Verbose
-                    or LogEventLevel.Debug
-                    or LogEventLevel.Information => LogType.Log,
-
-                    LogEventLevel.Warning => LogType.Warning,
-
-                    LogEventLevel.Error or LogEventLevel.Fatal => LogType.Error,
-
-                    _ => throw new ArgumentOutOfRangeException(nameof(logEvent.Level), "Unknown log level")
-                };
+                    case LogEventLevel.Verbose:
+                    case LogEventLevel.Debug:
+                    case LogEventLevel.Information:
+                        logType = LogType.Log;
+                        break;
+                    case LogEventLevel.Warning:
+                        logType = LogType.Warning;
+                        break;
+                    case LogEventLevel.Error:
+                    case LogEventLevel.Fatal:
+                        logType = LogType.Error;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(logEvent.Level), "Unknown log level");
+                }
 
                 object message = buffer.ToString().Trim();
 
                 if (TryGetContext(logEvent, out var context))
                 {
-                    _logger.Log(level, message, context);
+                    _logger.Log(logType, message, context);
                 }
                 else
                 {
-                    _logger.Log(level, message);
+                    _logger.Log(logType, message);
                 }
             }
         }

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
@@ -2,6 +2,7 @@
 using Serilog.Events;
 using Serilog.Formatting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
@@ -9,9 +10,18 @@ namespace Serilog.Sinks.Unity3D
 {
     public sealed class Unity3DLogEventSink : ILogEventSink
     {
-        private readonly ITextFormatter _formatter;
+        public const string UNITY_CONTEXT_KEY = "%UNITY_ID%";
 
-        public Unity3DLogEventSink(ITextFormatter formatter) => _formatter = formatter;
+        static internal readonly Dictionary<int, UnityEngine.Object> _objectstoLog = new Dictionary<int, UnityEngine.Object>();
+
+        private readonly ITextFormatter _formatter;
+        private readonly UnityEngine.ILogger _logger;
+
+        public Unity3DLogEventSink(ITextFormatter formatter, UnityEngine.ILogger logger = null)
+        {
+            _formatter = formatter;
+            _logger = Debug.unityLogger;
+        }
 
         public void Emit(LogEvent logEvent)
         {
@@ -19,26 +29,45 @@ namespace Serilog.Sinks.Unity3D
             {
                 _formatter.Format(logEvent, buffer);
 
-                switch (logEvent.Level)
+                var level = logEvent.Level switch
                 {
-                    case LogEventLevel.Verbose:
-                    case LogEventLevel.Debug:
-                    case LogEventLevel.Information:
-                        Debug.Log(buffer.ToString().Trim());
-                        break;
+                    LogEventLevel.Verbose
+                    or LogEventLevel.Debug
+                    or LogEventLevel.Information => LogType.Log,
 
-                    case LogEventLevel.Warning:
-                        Debug.LogWarning(buffer.ToString().Trim());
-                        break;
+                    LogEventLevel.Warning => LogType.Warning,
 
-                    case LogEventLevel.Error:
-                    case LogEventLevel.Fatal:
-                        Debug.LogError(buffer.ToString().Trim());
-                        break;
+                    LogEventLevel.Error or LogEventLevel.Fatal => LogType.Error,
 
-                    default: throw new ArgumentOutOfRangeException(nameof(logEvent.Level), "Unknown log level");
+                    _ => throw new ArgumentOutOfRangeException(nameof(logEvent.Level), "Unknown log level")
+                };
+
+                if (TryGetContext(logEvent, out var context))
+                {
+                    _logger.Log(level, "", buffer.ToString().Trim(), context);
+                }
+                else
+                {
+                    _logger.Log(level, buffer.ToString().Trim());
                 }
             }
+        }
+
+        private static bool TryGetContext(LogEvent logEvent, out UnityEngine.Object unityContext)
+        {
+            unityContext = null;
+#if UNITY_EDITOR 
+            if (logEvent.Properties.TryGetValue(UNITY_CONTEXT_KEY, out var propertyValue)
+                && propertyValue is ScalarValue scalarValue
+                && scalarValue.Value is int id
+                && _objectstoLog.TryGetValue(id, out var unityObj))
+            {
+                unityContext = unityObj;
+                _objectstoLog.Remove(id);
+                return true;
+            }
+#endif
+            return false;
         }
     }
 }

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
@@ -1,10 +1,9 @@
-﻿using Serilog.Core;
-using Serilog.Events;
-using Serilog.Formatting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
 using UnityEngine;
 
 namespace Serilog.Sinks.Unity3D
@@ -21,7 +20,7 @@ namespace Serilog.Sinks.Unity3D
         public Unity3DLogEventSink(ITextFormatter formatter, UnityEngine.ILogger logger = null)
         {
             _formatter = formatter;
-            _logger = Debug.unityLogger;
+            _logger = logger ?? Debug.unityLogger;
         }
 
         public void Emit(LogEvent logEvent)

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Unity3DLogEventSink.cs
@@ -4,6 +4,7 @@ using Serilog.Formatting;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace Serilog.Sinks.Unity3D
@@ -42,13 +43,15 @@ namespace Serilog.Sinks.Unity3D
                     _ => throw new ArgumentOutOfRangeException(nameof(logEvent.Level), "Unknown log level")
                 };
 
+                object message = buffer.ToString().Trim();
+
                 if (TryGetContext(logEvent, out var context))
                 {
-                    _logger.Log(level, "", buffer.ToString().Trim(), context);
+                    _logger.Log(level, message, context);
                 }
                 else
                 {
-                    _logger.Log(level, buffer.ToString().Trim());
+                    _logger.Log(level, message);
                 }
             }
         }

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/UnitySinkExtensions.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/UnitySinkExtensions.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Display;
 using System;
+using System.Collections.Generic;
 
 namespace Serilog.Sinks.Unity3D
 {
@@ -52,12 +53,23 @@ namespace Serilog.Sinks.Unity3D
             this LoggerSinkConfiguration sinkConfiguration,
             ITextFormatter formatter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            UnityEngine.ILogger logger = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
 
-            return sinkConfiguration.Sink(new Unity3DLogEventSink(formatter), restrictedToMinimumLevel, levelSwitch);
+            return sinkConfiguration.Sink(new Unity3DLogEventSink(formatter, logger), restrictedToMinimumLevel, levelSwitch);
+        }
+
+
+        public static ILogger WithUnityContext(this ILogger logger, UnityEngine.Object context)
+        {
+            int id = context.GetInstanceID();
+#if UNITY_EDITOR
+            Unity3DLogEventSink._objectstoLog.TryAdd(id, context);
+#endif
+            return logger.ForContext(Unity3DLogEventSink.UNITY_CONTEXT_KEY, id);
         }
     }
 }


### PR DESCRIPTION
* Add support for unity context object (use UnitySinkExtensions.WithUnityContext)
* Use UnityEngine.ILogger instead of Debug.log for better flexibility

_I know the dictionary implementation is not that great, but I didn't find another way to pass raw object to the sink for now_