### PR TITLE
Add support for Serilog.Extensions.Logging

### DIFF
--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d025faec52e1234bacf13031de20526
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/Serilog.Sinks.Unity3D.Extensions.Logging.asmdef
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/Serilog.Sinks.Unity3D.Extensions.Logging.asmdef
@@ -1,0 +1,28 @@
+{
+    "name": "Serilog.Sinks.Unity3D.Extensions.Logging",
+    "rootNamespace": "",
+    "references": [
+        "GUID:ebcad7e3972724c43aa595f17cf4d103"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Serilog.dll",
+        "Serilog.Extensions.Logging.dll",
+        "Microsoft.Extensions.Logging.Abstractions.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "HAS_SERILOG_EXTENSIONS_LOGGING"
+    ],
+    "versionDefines": [
+        {
+            "name": "org.nuget.serilog.extensions.logging",
+            "expression": "",
+            "define": "HAS_SERILOG_EXTENSIONS_LOGGING"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/Serilog.Sinks.Unity3D.Extensions.Logging.asmdef.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/Serilog.Sinks.Unity3D.Extensions.Logging.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f94b348d662815649a7508205ced4fad
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+using System;
+
+namespace Serilog.Sinks.Unity3D
+{
+    public static class SerilogUnityContextScopeExtensions
+    {
+        /// <summary>
+        /// <para>
+        /// Enables <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}(TState)"/> to play nicely with <see cref="UnityEngine.Object"/>.
+        /// This way you can use e.g. <code>log.BeginScope(gameObject)</code> and the log entry will be clickable in Unity's console window.
+        /// </para>
+        /// <para>
+        /// To be used in conjunction with <see cref="SerilogUnityContextScopeExtensions.AddSerilogWithUnityObjectScope(Microsoft.Extensions.Logging.ILoggerFactory, ILogger?, bool)"/>
+        /// when you set up your factory:
+        /// <code>
+        /// new Microsoft.Extensions.Logging.LoggerFactory().AddSerilogWithUnityObjectScope(logger, dispose: true)
+        /// </code>
+        /// </para>
+        /// </summary>
+        /// <param name="loggerConfiguration"></param>
+        /// <returns></returns>
+        public static LoggerConfiguration EnableUnityObjectScope(this LoggerConfiguration loggerConfiguration)
+        {
+            return loggerConfiguration
+                .Destructure.With<UnityObjectDestructuringPolicy>();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Add Serilog to the logging pipeline and enable <see cref="UnityEngine.Object"/> to be used with <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}(TState)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="factory">The logger factory to configure.</param>
+        /// <param name="logger">The Serilog logger; if not supplied, the static <see cref="Serilog.Log"/> will be used.</param>
+        /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
+        /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
+        /// called on the static <see cref="Log"/> class instead.</param>
+        /// <returns>Reference to the supplied <paramref name="factory"/>.</returns>
+        public static Microsoft.Extensions.Logging.ILoggerFactory AddSerilogWithUnityObjectScope(
+            this Microsoft.Extensions.Logging.ILoggerFactory factory,
+            Serilog.ILogger? logger = null,
+            bool dispose = false)
+        {
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+            factory.AddProvider(new SerilogUnityContextScopeLoggerProvider(logger, dispose));
+
+            return factory;
+        }
+    }
+}

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs
@@ -36,15 +36,19 @@ namespace Serilog.Sinks.Unity3D
         /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
         /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
         /// called on the static <see cref="Log"/> class instead.</param>
+        /// <param name="unityObjectScopeTransformer">Can optionally be used to transform <see cref="UnityEngine.Object"/>s to
+        /// something else when calling <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}(TState)"/> with an
+        /// <see cref="UnityEngine.Object"/> argument. Influences how this object gets represented in the logger's scope.</param>
         /// <returns>Reference to the supplied <paramref name="factory"/>.</returns>
         public static Microsoft.Extensions.Logging.ILoggerFactory AddSerilogWithUnityObjectScope(
             this Microsoft.Extensions.Logging.ILoggerFactory factory,
             Serilog.ILogger? logger = null,
-            bool dispose = false)
+            bool dispose = false,
+            UnityObjectTransformerDelegate? unityObjectScopeTransformer = null)
         {
             if (factory == null) throw new ArgumentNullException(nameof(factory));
 
-            factory.AddProvider(new SerilogUnityContextScopeLoggerProvider(logger, dispose));
+            factory.AddProvider(new SerilogUnityContextScopeLoggerProvider(logger, dispose, unityObjectScopeTransformer));
 
             return factory;
         }

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bf169c22685fd54cb8e17ce3913cfaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
@@ -1,0 +1,74 @@
+﻿#nullable enable
+using Serilog.Context;
+using System.Collections.Generic;
+using System;
+
+namespace Serilog.Sinks.Unity3D
+{
+    /// <summary>
+    /// A wrapper around <see cref="Serilog.Extensions.Logging.SerilogLogger"/>.
+    /// Keeps track of <see cref="UnityEngine.Object"/>s used as scope items.
+    /// </summary>
+    public class SerilogUnityContextScopeLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        private SerilogUnityContextScopeLoggerProvider serilogForUnityLoggerProvider;
+        private readonly Microsoft.Extensions.Logging.ILogger _logger;
+
+        private Stack<UnityContextScope> _unityContextStack = new Stack<UnityContextScope>();
+
+        public SerilogUnityContextScopeLogger(SerilogUnityContextScopeLoggerProvider serilogForUnityLoggerProvider, Microsoft.Extensions.Logging.ILogger logger)
+        {
+            this.serilogForUnityLoggerProvider = serilogForUnityLoggerProvider;
+            _logger = logger;
+        }
+
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (_unityContextStack.TryPeek(out var unityContextScope))
+            {
+                LogContext.PushProperty(UnityObjectEnricher.UnityContextKey, unityContextScope.UnityContext, true);
+            }
+
+            _logger.Log(logLevel, eventId, state, exception, formatter);
+        }
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+        {
+            return _logger.IsEnabled(logLevel);
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            var scopeDisposable = _logger.BeginScope(state);
+
+            if (state is UnityEngine.Object unityContext)
+            {
+                var unityContextScope = new UnityContextScope(this, scopeDisposable, unityContext);
+                _unityContextStack.Push(unityContextScope);
+                return unityContextScope;
+            }
+
+            return scopeDisposable;
+        }
+
+        private class UnityContextScope : IDisposable
+        {
+            private readonly SerilogUnityContextScopeLogger _logger;
+            private readonly IDisposable? _chainedDisposable;
+            public UnityEngine.Object UnityContext { get; private set; }
+
+            public UnityContextScope(SerilogUnityContextScopeLogger logger, IDisposable? chainedDisposable, UnityEngine.Object unityContext)
+            {
+                _logger = logger;
+                _chainedDisposable = chainedDisposable;
+                UnityContext = unityContext;
+            }
+
+            public void Dispose()
+            {
+                _logger._unityContextStack.Pop();
+                _chainedDisposable?.Dispose();
+            }
+        }
+    }
+}

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
@@ -11,14 +11,12 @@ namespace Serilog.Sinks.Unity3D
     /// </summary>
     public class SerilogUnityContextScopeLogger : Microsoft.Extensions.Logging.ILogger
     {
-        private SerilogUnityContextScopeLoggerProvider serilogForUnityLoggerProvider;
         private readonly Microsoft.Extensions.Logging.ILogger _logger;
 
         private Stack<UnityContextScope> _unityContextStack = new Stack<UnityContextScope>();
 
-        public SerilogUnityContextScopeLogger(SerilogUnityContextScopeLoggerProvider serilogForUnityLoggerProvider, Microsoft.Extensions.Logging.ILogger logger)
+        public SerilogUnityContextScopeLogger(Microsoft.Extensions.Logging.ILogger logger)
         {
-            this.serilogForUnityLoggerProvider = serilogForUnityLoggerProvider;
             _logger = logger;
         }
 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs
@@ -53,13 +53,25 @@ namespace Serilog.Sinks.Unity3D
         {
             private readonly SerilogUnityContextScopeLogger _logger;
             private readonly IDisposable? _chainedDisposable;
-            public UnityEngine.Object UnityContext { get; private set; }
+
+            private readonly WeakReference<UnityEngine.Object> _unityContextReference;
+
+            public UnityEngine.Object? UnityContext
+            {
+                get
+                {
+                    if (_unityContextReference.TryGetTarget(out var result) == false)
+                        return null;
+
+                    return result;
+                }
+            }
 
             public UnityContextScope(SerilogUnityContextScopeLogger logger, IDisposable? chainedDisposable, UnityEngine.Object unityContext)
             {
                 _logger = logger;
                 _chainedDisposable = chainedDisposable;
-                UnityContext = unityContext;
+                _unityContextReference = new WeakReference<UnityEngine.Object>(unityContext);
             }
 
             public void Dispose()

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cc5dda9e0b90e142a028aa25bff74de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
@@ -3,21 +3,25 @@ using Serilog.Extensions.Logging;
 
 namespace Serilog.Sinks.Unity3D
 {
+    public delegate object UnityObjectTransformerDelegate(UnityEngine.Object obj);
+
     /// <summary>
     /// A thin wrapper around <see cref="SerilogLoggerProvider"/>.
     /// </summary>
     public class SerilogUnityContextScopeLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
     {
         private readonly SerilogLoggerProvider _innerProvider;
+        private readonly UnityObjectTransformerDelegate? _unityObjectTransformer;
 
-        public SerilogUnityContextScopeLoggerProvider(ILogger? logger, bool dispose)
+        public SerilogUnityContextScopeLoggerProvider(ILogger? logger, bool dispose, UnityObjectTransformerDelegate? unityObjectTransformer = null)
         {
             _innerProvider = new SerilogLoggerProvider(logger, dispose);
+            _unityObjectTransformer = unityObjectTransformer;
         }
 
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
         {
-            return new SerilogUnityContextScopeLogger(_innerProvider.CreateLogger(categoryName));
+            return new SerilogUnityContextScopeLogger(_innerProvider.CreateLogger(categoryName), _unityObjectTransformer);
         }
 
         public void Dispose()

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+using Serilog.Extensions.Logging;
+
+namespace Serilog.Sinks.Unity3D
+{
+    /// <summary>
+    /// A thin wrapper around <see cref="SerilogLoggerProvider"/>.
+    /// </summary>
+    public class SerilogUnityContextScopeLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
+    {
+        private readonly SerilogLoggerProvider _innerProvider;
+
+        public SerilogUnityContextScopeLoggerProvider(ILogger? logger, bool dispose)
+        {
+            _innerProvider = new SerilogLoggerProvider(logger, dispose);
+        }
+
+        public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+        {
+            return new SerilogUnityContextScopeLogger(this, _innerProvider.CreateLogger(categoryName));
+        }
+
+        public void Dispose()
+        {
+            _innerProvider.Dispose();
+        }
+    }
+}

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Unity3D
 
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
         {
-            return new SerilogUnityContextScopeLogger(this, _innerProvider.CreateLogger(categoryName));
+            return new SerilogUnityContextScopeLogger(_innerProvider.CreateLogger(categoryName));
         }
 
         public void Dispose()

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/SerilogUnityContextScopeLoggerProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48cee4520c4f7d1488b09c00bdbffb02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/UnityObjectDestructuringPolicy.cs
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/UnityObjectDestructuringPolicy.cs
@@ -1,0 +1,26 @@
+﻿#nullable enable
+using Serilog.Core;
+using Serilog.Events;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Serilog.Sinks.Unity3D
+{
+    /// <summary>
+    /// Makes sure we destructure <see cref="UnityEngine.Object"/>s as scalars, i.e. keeping their reference.
+    /// </summary>
+    internal class UnityObjectDestructuringPolicy : IDestructuringPolicy
+    {
+        public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, [NotNullWhen(true)] out LogEventPropertyValue? result)
+        {
+            result = null;
+
+            if (value is UnityEngine.Object unityObject)
+            {
+                result = new ScalarValue(unityObject);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/UnityObjectDestructuringPolicy.cs.meta
+++ b/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D/Serilog.Extensions.Logging/UnityObjectDestructuringPolicy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b7f1405e6865e544a3fcebfd870fc4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Based on the discussion in #9, here's support for using `UnityEngine.Object`s with `BeginScope()` and using the latest pushed scope as context when sending following log entries to Unity's console window.

This way, log entries are clickable and e.g. `GameObject`s get pinged in the editor.

On key design choice from a user's perspective was to avoid additonal APIs or dependencies. User code only needs to reference `Microsoft.Extensions.Logging.ILogger` and work with the abstractions. Everything else is done upfront via configuration.

## Example
Config:
```csharp
Serilog.Core.Logger logger = new Serilog.LoggerConfiguration()
    .MinimumLevel.Information()
    .Enrich.FromLogContext()
    .WriteTo.Unity3D()
    .EnableUnityObjectScope() // Important to add!
    .CreateLogger();

var loggerFactory = new Microsoft.Extensions.Logging.LoggerFactory()
    .AddSerilogWithUnityObjectScope(logger, dispose: true); // Also important! Use this instead of .AddSerilog(...)
```
Usage:
```csharp
// Grab a logger manually for the example's sake. Usually done via DI.
var log = loggerFactory.CreateLogger("SomeCategory");

using (var scope = log.BeginScope(gameObject))
{
    log.LogInformation($"You can click me to ping {gameObject.name}"); // Produces a clickable log entry inside this scope
}

log.LogInformation($"Now you can _not_ click me to ping {gameObject.name}");
```

## Async/await support
It also works with async/await code as long as it is managed by Unity's main thread. UniTask should work fine, too.
```csharp
async Task LogFromTask(UnityEngine.Object unityContext, string msg)
{
    using var scope = log.BeginScope(unityContext);

    for (int i = 0; i < 5; i++)
    {
        await Task.Delay(TimeSpan.FromMilliseconds(300));
        log.LogInformation(msg);
    }
}

var t1 = LogFromTask(gameObject, "T1");
var t2 = LogFromTask(Camera.main, "T2");

await Task.WhenAll(t1, t2); // Both task log in parallel with separate scopes
```

## No thread safety for UnityEngine.Objects
This stems from the known Unity limitation: Access to all/most members of its managed-lifecycle objects is limited to the main thread.

So when calling e.g. `BeginScope(gameObject)` on other threads the library throws an `NotSupportedException` to keep it from failing somewhere else down the line (like in enrichers or sinks).

Everything else works fine from other threads.

## Optional integration
The new functionality lives in a separate assembly (`Serilog.Sinks.Unity3D.Extensions.Logging`). The assembly definition makes sure it only compiles when the dependencies are in place, namely the package `org.nuget.serilog.extensions.logging` (which in turn depends on Serilog and Microsoft's abstractions).

If the dependencies are not found, the base sink (Serilog.Sinks.Unity3D) still works just like before.

## Installation via manifest.json
```json
{
  "scopedRegistries": [
    {
      "name": "Unity NuGet",
      "url": "https://unitynuget-registry.azurewebsites.net",
      "scopes": [
        "org.nuget"
      ]
    }
  ],
  "dependencies": {
    "org.nuget.serilog.extensions.logging": "8.0.0",
    "com.serilog.sinks.unity3d": "https://github.com/krisrok/Serilog.Sinks.Unity3D.git?path=/Serilog.Sinks.Unity3D/Assets/Serilog.Sinks.Unity3D#3.0.0-ext",
    ...
```